### PR TITLE
Refresh token before expiration

### DIFF
--- a/Resources/views/Form/karser_recaptcha3_widget.html.twig
+++ b/Resources/views/Form/karser_recaptcha3_widget.html.twig
@@ -9,6 +9,7 @@
                     grecaptcha.execute('{{ form.vars.site_key }}', {action: '{{ form.vars.action_name }}'}).then(function(token) {
                         document.getElementById('{{ id }}').value = token;
                     });
+                    setTimeout(recaptchaCallback_{{ id }}, 100000);
                 };
             </script>
             <script src="https://www.google.com/recaptcha/api.js?render={{ form.vars.site_key }}&onload=recaptchaCallback_{{ id }}" async defer></script>


### PR DESCRIPTION
Since the token expires after 2 minutes I recommend adding a call a bit before the expiration to refresh the token.