### PR TITLE
Substitute hyphens by underscores to generate recaptcha callback valid name

### DIFF
--- a/Resources/views/Form/karser_recaptcha3_widget.html.twig
+++ b/Resources/views/Form/karser_recaptcha3_widget.html.twig
@@ -4,15 +4,16 @@
         {{ block('form_widget_simple') }}
 
         {% if form.vars.enabled -%}
+            {% set validJsId = id | replace({'-':'_'})  %}
             <script type="text/javascript" {% if form.vars.script_nonce_csp is defined %}nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
-                var recaptchaCallback_{{ id }} = function() {
+                var recaptchaCallback_{{ validJsId }} = function() {
                     grecaptcha.execute('{{ form.vars.site_key }}', {action: '{{ form.vars.action_name }}'}).then(function(token) {
                         document.getElementById('{{ id }}').value = token;
                     });
-                    setTimeout(recaptchaCallback_{{ id }}, 100000);
+                    setTimeout(recaptchaCallback_{{ validJsId }}, 100000);
                 };
             </script>
-            <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render={{ form.vars.site_key }}&onload=recaptchaCallback_{{ id }}" async defer></script>
+            <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render={{ form.vars.site_key }}&onload=recaptchaCallback_{{ validJsId }}" async defer></script>
 
         {%- endif %}
     {% endapply %}


### PR DESCRIPTION

Hyphens are often used in html id attributes, but they are not allowed for variable names in JavaScript, breaking generated recaptcha code.