### PR TITLE
Add missing errorNames to Recaptcha3 validator constraint

### DIFF
--- a/Tests/Validator/Constraints/Recaptcha3ValidatorTest.php
+++ b/Tests/Validator/Constraints/Recaptcha3ValidatorTest.php
@@ -107,4 +107,11 @@ class Recaptcha3ValidatorTest extends ConstraintValidatorTestCase
         $validator->validate('test', new Recaptcha3());
         self::assertNotNull($validator->getLastResponse());
     }
+
+    public function testGetErrorName()
+    {
+        $constraint = new Recaptcha3();
+
+        self::assertSame('INVALID_FORMAT_ERROR', $constraint::getErrorName('7147ffdb-0af4-4f7a-bd5e-e9dcfa6d7a2d'));
+    }
 }

--- a/Validator/Constraints/Recaptcha3.php
+++ b/Validator/Constraints/Recaptcha3.php
@@ -11,6 +11,10 @@ final class Recaptcha3 extends Constraint
 {
     const INVALID_FORMAT_ERROR = '7147ffdb-0af4-4f7a-bd5e-e9dcfa6d7a2d';
 
+    protected static $errorNames = [
+        self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
+    ];
+
     public $message = 'Your computer or network may be sending automated queries';
     public $messageMissingValue = 'The captcha value is missing';
 }


### PR DESCRIPTION
This will allow $constraint::getErrorName() usage