### PR TITLE
PHP8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "phpfui/recaptcha": "^2.0",
     "symfony/form": "^3.4|^4.0|^5.0|^6.0|^7.0",
     "symfony/framework-bundle": "^3.4.26|^4.2.7|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "google/recaptcha": "^1.2",
+    "phpfui/recaptcha": "^2.0",
     "symfony/form": "^3.4|^4.0|^5.0|^6.0|^7.0",
     "symfony/framework-bundle": "^3.4.26|^4.2.7|^5.0|^6.0|^7.0",
     "symfony/expression-language": "^3.4|^4.0|^5.0|^6.0|^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
         bootstrap="vendor/autoload.php"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
         displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnPhpunitDeprecations="true"
 >
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,13 +4,15 @@
         colors="true"
         bootstrap="vendor/autoload.php"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnPhpunitDeprecations="true"
 >
     <testsuites>
         <testsuite name="KarserRecaptcha3Bundle Test Suite">
             <directory>./Tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">.</directory>
         </include>
@@ -19,5 +21,7 @@
             <directory>Tests</directory>
             <directory>vendor</directory>
         </exclude>
+    </source>
+    <coverage>
     </coverage>
 </phpunit>


### PR DESCRIPTION
Migrating from `google/recaptcha` to `phpfui/recaptcha`, which is a fork from the original author, as Google does not assure the maintenance on the main repository. See https://github.com/google/recaptcha/pull/563
The fork mainly add type hinting to the library https://github.com/google/recaptcha/commit/513dd16f11354094791b01b21aded467f3577e58

I also change the PHP requirement to 7.4+, to be sure the introduced type hinting is supported (including return values).

Fix #80